### PR TITLE
Possible fix for command line options - please test.

### DIFF
--- a/BabylonReader/BabylonBglParser.cs
+++ b/BabylonReader/BabylonBglParser.cs
@@ -66,20 +66,22 @@ namespace BabylonToHtml.BabylonReader
                 s.Seek(gzipHeaderPos, SeekOrigin.Begin);
                 parseMetaData(new GZipInputStream(s));
 
-                if (string.IsNullOrWhiteSpace(this.SrcEnc))
+                if (null == this.SrcEncoding && string.IsNullOrWhiteSpace(this.SrcEnc))
                 {
                     throw new InvalidDataException("Failed to detect source encoding in BGL file. Please provide encoding via proper constructor.");
                 }
-                else
+                else if (null == this.SrcEncoding)
                 {
+                    // if SrcEncoding not set at command line
                     this.SrcEncoding = Encoding.GetEncoding(this.SrcEnc);
                 }
-                if (string.IsNullOrWhiteSpace(this.DstEnc))
+                if (null == this.DstEncoding && string.IsNullOrWhiteSpace(this.DstEnc))
                 {
                     throw new InvalidDataException("Failed to detect destination encoding in BGL file. Please provide encoding via proper constructor.");
                 }
-                else
+                else if (null == this.DstEncoding)
                 {
+                    // if DstEncoding not set at command line
                     this.DstEncoding = Encoding.GetEncoding(this.DstEnc);
                 }
 

--- a/Program.cs
+++ b/Program.cs
@@ -116,14 +116,7 @@ namespace BabylonToHtml
                 Console.Write("Processing input...\n\n");
 
                 BabylonBglParser parser;
-                if ((sourceEnc != null) && (targetEnc != null))
-                {
-                    parser = new BabylonBglParser(sourceEnc, targetEnc);
-                }
-                else
-                {
-                    parser = new BabylonBglParser();
-                }
+                parser = new BabylonBglParser(sourceEnc, targetEnc);
                 XDict dict = parser.Parse(fileName);
 
                 WriteKeyValue("Dictionary title", parser.Title);


### PR DESCRIPTION
Previously both source and target encodings were necessary for using the
correct BabylonBglParser constructor. This fix makes them optional and
will use the detected encoding if not provided. This fix also enforces
the BabylonBglParser object to use the command line provided encodings.
